### PR TITLE
Fix syntax of rm command that fails build.

### DIFF
--- a/golang.mk
+++ b/golang.mk
@@ -42,7 +42,7 @@ lint:
 	$(foreach pkg,$(GOPKGS),golint $(pkg);)
 
 go_generate:
-	rm mocks -rvf
+	rm -rvf mocks
 	go generate ./...
 
 test_packages: vendor


### PR DESCRIPTION
Fix syntax of rm command that fails build.

Order options correctly in rm command.